### PR TITLE
use document client size instead of window inner size to fix iOS9.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,9 @@ function fit(canvas, parent, scale) {
       var width  = psize[0]|0
       var height = psize[1]|0
     } else {
-      var width  = window.innerWidth
-      var height = window.innerHeight
+      var element = document.documentElement
+      var width  = element.clientWidth
+      var height = element.clientHeight
     }
 
     if (isSVG) {


### PR DESCRIPTION
If you use the following meta, iOS9.1 will _occasionally_ report incorrect `window.innerWidth/Height` values on page load.

``` html
<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
```

This causes most apps using `canvas-fit` to break when they also have a meta tag like this.

I'm hoping there is a better solution that doesn't involve changing `canvas-fit` module. But here is one approach to fixing it; the `document.documentElement` client size returns correct results on iOS9.1. It also does not _appear_ to cause any other side effects... 

Related:
https://github.com/stackgl/ray-aabb-intersection/issues/2
https://twitter.com/search?q=ios9%20innerheight&src=typd

Thoughts?
